### PR TITLE
remove arbitrary impact sound spam

### DIFF
--- a/Source/AAKplayer.cpp
+++ b/Source/AAKplayer.cpp
@@ -6287,8 +6287,12 @@ F32 AAKPlayer::_doCollisionImpact( const Collision *collision, bool fallingColli
    if ( ((bd > mDataBlock->minImpactSpeed && fallingCollision) || bd > mDataBlock->minLateralImpactSpeed) 
       && !mMountPending )
    {
-      if ( !isGhost() )
-         onImpact( collision->object, collision->normal * bd );
+      if (!isGhost())
+      {
+         onImpact(collision->object, collision->normal * bd);
+         mImpactSound = AAKPlayerData::ImpactNormal;
+         setMaskBits(ImpactMask);
+      }
 
       if (mDamageState == Enabled && mState != RecoverState) 
       {
@@ -6312,13 +6316,6 @@ F32 AAKPlayer::_doCollisionImpact( const Collision *collision, bool fallingColli
             setState(RecoverState, recover);
          }*/
       }
-   }
-
-   if ( isServerObject() && 
-      (bd > (mDataBlock->minImpactSpeed / 3.0f) || bd > (mDataBlock->minLateralImpactSpeed / 3.0f )) ) 
-   {
-      mImpactSound = AAKPlayerData::ImpactNormal;
-      setMaskBits(ImpactMask);
    }
 
    return bd;


### PR DESCRIPTION
1) don't call them when onimpact threshold isn't crossed. 2) *definitely* don't call them with an arbirtary /3 threshold