### PR TITLE
followup to #22

### DIFF
--- a/Source/AAKplayer.cpp
+++ b/Source/AAKplayer.cpp
@@ -342,7 +342,6 @@ AAKPlayerData::AAKPlayerData() : PlayerData()
 	landDuration = 100.0f;
 	landSpeedFactor = 0.5f;
    mDynamicAnimsStart = NumTableActionAnims;
-   dMemset(actionList, 0, sizeof(actionList));
 }
 
 bool AAKPlayerData::preload(bool server, String& errorStr)

--- a/Source/AAKplayer.h
+++ b/Source/AAKplayer.h
@@ -159,7 +159,6 @@ struct AAKPlayerData: public PlayerData {
       NullAnimation = (1 << ActionAnimBits) - 1
    };
    static ActionAnimationDef ActionAnimationList[NumTableActionAnims];
-   ActionAnimation actionList[NumActionAnims];
 
    DECLARE_CONOBJECT(AAKPlayerData);
    AAKPlayerData();


### PR DESCRIPTION
remove shadow    ActionAnimation actionList[NumActionAnims];
parent's already got it, and we don't want things getting confused which one of the 512 potential animations can be sloted in. nor, obviously, allocated twice.